### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build Docker Image
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 

--- a/.github/workflows/buildNative.yml
+++ b/.github/workflows/buildNative.yml
@@ -1,4 +1,6 @@
 name: Build Docker Native Image
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,8 @@ jobs:
   post-merge-actions:
     name: Post-Merge (Version, Changelog, Release, Notify)
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     # Only run if a PR was successfully merged into the main branch
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     needs: [ tests ] # Ensures tests passed on the merge commit

--- a/.github/workflows/wiki-publish.yml
+++ b/.github/workflows/wiki-publish.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   publish-migration-guide:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout main repository
         uses: actions/checkout@v6


### PR DESCRIPTION
Potential fix for [https://github.com/cytechmobile/sendium/security/code-scanning/5](https://github.com/cytechmobile/sendium/security/code-scanning/5)

In general, the fix is to explicitly declare a `permissions` block either at the workflow root (to affect all jobs) or specifically on the `post-merge-actions` job, and scope it down to the minimal rights the job needs. Because the `tests` and `automerge-dependabot` jobs already work (and one of them already has its own `permissions`), the safest, least intrusive fix is to add a `permissions` block directly to `post-merge-actions`.

This job needs to: (1) read and write repository contents (checkout, pull, push, tags), and (2) create a GitHub Release via `softprops/action-gh-release`, which uses the `GITHUB_TOKEN` for repository/contents operations. It does not use issues, pull requests, or other resources. So we can define `permissions` for this job as `contents: write`, leaving all other scopes at their default of `none`. Concretely, in `.github/workflows/ci.yml`, just under the `post-merge-actions:` job definition (around line 95), add a `permissions:` block with `contents: write` at the same indentation level as `runs-on`. No other functional changes or imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
