### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ concurrency:
 
 jobs:
   tests:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/cytechmobile/sendium/security/code-scanning/8](https://github.com/cytechmobile/sendium/security/code-scanning/8)

To fix the problem, we should explicitly limit the `GITHUB_TOKEN` permissions for the `tests` job to the least privileges it needs. From the provided snippet, `tests` only needs to read repository contents (for `actions/checkout`) and does not perform any GitHub write operations. Therefore, adding `permissions: contents: read` to that job is sufficient. Other jobs already define their own, more permissive, blocks where needed.

The best minimal change without altering existing functionality is:

- Add a `permissions:` block under `jobs: tests:` (at the same indentation level as `runs-on:`) with `contents: read`.
- Leave the existing `permissions` blocks for `post-merge-actions` and `automerge-dependabot` unchanged.
- No additional imports, methods, or definitions are required because this is a YAML configuration change only.

Concretely, in `.github/workflows/ci.yml`, between line 12 (`tests:`) and line 13 (`runs-on: ubuntu-latest`), insert:

```yaml
    permissions:
      contents: read
```

This will ensure that the `tests` job runs with read-only contents access, satisfying CodeQL’s recommendation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
