### PR TITLE
fix(Routing): Use double precision for floating routing rules

### DIFF
--- a/sendium-core/src/main/java/gr/cytech/sendium/core/message/CoreMessage.java
+++ b/sendium-core/src/main/java/gr/cytech/sendium/core/message/CoreMessage.java
@@ -13,6 +13,8 @@ public interface CoreMessage {
 
     public long getLongValue(int pidx) throws IllegalArgumentException;
 
+    public double getDoubleValue(int pidx) throws IllegalArgumentException;
+
     public float getFloatValue(int pidx) throws IllegalArgumentException;
 
     public short getShortValue(int pidx) throws IllegalArgumentException;

--- a/sendium-core/src/main/java/gr/cytech/sendium/core/message/StandardMessage.java
+++ b/sendium-core/src/main/java/gr/cytech/sendium/core/message/StandardMessage.java
@@ -638,13 +638,34 @@ public class StandardMessage implements Comparable<StandardMessage>, CoreMessage
                 case 42: return (Float) field8;
                 case 43: return (Float) field9;
                 case 44: return (Float) field10;
-                case 71: return (float) marginPercentage;
             }
         } catch (Exception e) {
             logger.warn("error converting field {} to float", pidx);
         }
         throw new IllegalArgumentException("Field number: " + pidx + " is not float");
     }
+
+    public double getDoubleValue(int pidx) throws IllegalArgumentException {
+        try {
+            switch (pidx) {
+                case 35: return ((Number) field1).doubleValue();
+                case 36: return ((Number) field2).doubleValue();
+                case 37: return ((Number) field3).doubleValue();
+                case 38: return ((Number) field4).doubleValue();
+                case 39: return ((Number) field5).doubleValue();
+                case 40: return ((Number) field6).doubleValue();
+                case 41: return ((Number) field7).doubleValue();
+                case 42: return ((Number) field8).doubleValue();
+                case 43: return ((Number) field9).doubleValue();
+                case 44: return ((Number) field10).doubleValue();
+                case 71: return marginPercentage;
+            }
+        } catch (Exception e) {
+            logger.warn("error converting field {} to double", pidx);
+        }
+        throw new IllegalArgumentException("Field number: " + pidx + " is not double");
+    }
+
 
     public char getCharValue(int pidx) throws IllegalArgumentException {
         try {

--- a/sendium-core/src/main/java/gr/cytech/sendium/routing/RoutingRule.java
+++ b/sendium-core/src/main/java/gr/cytech/sendium/routing/RoutingRule.java
@@ -243,7 +243,7 @@ public class RoutingRule {
         private int intValue;
         private boolean booleanValue;
         private long longValue;
-        private float floatValue;
+        private double doubleValue;
         private short shortValue;
         private char charValue;
         private byte byteValue;
@@ -274,7 +274,7 @@ public class RoutingRule {
             intValue = 0;
             booleanValue = false;
             longValue = 0;
-            floatValue = 0;
+            doubleValue = 0;
             shortValue = 0;
             charValue = 0;
             byteValue = 0;
@@ -331,8 +331,8 @@ public class RoutingRule {
                     staticMsg.getLongValue(fieldIdx);
                     break; // long
                 case 5:
-                    staticMsg.getFloatValue(fieldIdx);
-                    break; // float
+                    staticMsg.getDoubleValue(fieldIdx);
+                    break; // float/double
                 case 6:
                     staticMsg.getShortValue(fieldIdx);
                     break; // short
@@ -370,8 +370,8 @@ public class RoutingRule {
                     longValue = Long.parseLong(value);
                     break; // long
                 case 5:
-                    floatValue = Float.parseFloat(value);
-                    break; // float
+                    doubleValue = Double.parseDouble(value);
+                    break; // float/double
                 case 6:
                     shortValue = Short.parseShort(value);
                     break; // short
@@ -560,8 +560,8 @@ public class RoutingRule {
                     match = matchLong(pMsg);
                     break; // long
                 case 5:
-                    match = matchFloat(pMsg);
-                    break; // float
+                    match = matchDouble(pMsg);
+                    break; // float/double
                 case 6:
                     match = matchShort(pMsg);
                     break; // short
@@ -673,19 +673,19 @@ public class RoutingRule {
             }
         }
 
-        private boolean matchFloat(CoreMessage pMsg) {
-            float msgVal = pMsg.getFloatValue(fieldIdx);
+        private boolean matchDouble(CoreMessage pMsg) {
+            double msgVal = pMsg.getDoubleValue(fieldIdx);
             switch (polIdx) {
                 case 12:
-                    return msgVal == floatValue;
+                    return msgVal == doubleValue;
                 case 13:
-                    return msgVal > floatValue;
+                    return msgVal > doubleValue;
                 case 14:
-                    return msgVal >= floatValue;
+                    return msgVal >= doubleValue;
                 case 15:
-                    return msgVal < floatValue;
+                    return msgVal < doubleValue;
                 case 16:
-                    return msgVal <= floatValue;
+                    return msgVal <= doubleValue;
                 default:
                     return false;
             }

--- a/sendium-core/src/test/java/gr/cytech/sendium/routing/RoutingRuleTest.java
+++ b/sendium-core/src/test/java/gr/cytech/sendium/routing/RoutingRuleTest.java
@@ -1,0 +1,46 @@
+package gr.cytech.sendium.routing;
+
+import gr.cytech.sendium.core.message.StandardMessage;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RoutingRuleTest {
+
+    @Test
+    void marginPercentageDoubleAccessorPreservesPrecision() {
+        StandardMessage msg = new StandardMessage();
+
+        msg.setValue(StandardMessage.fieldMap.get("marginPercentage"), "1.00000008");
+
+        assertEquals(1.00000008, msg.getDoubleValue(StandardMessage.fieldMap.get("marginPercentage")));
+        assertThrows(IllegalArgumentException.class, () -> msg.getFloatValue(StandardMessage.fieldMap.get("marginPercentage")));
+    }
+
+    @Test
+    void marginPercentageRoutingUsesDoublePrecision() {
+        StandardMessage msg = new StandardMessage();
+        msg.marginPercentage = 1.00000008;
+
+        RoutingRule equalsRoundedFloatRule =
+                new RoutingRule("marginPercentage", "==f", "1.00000007", "target", "label");
+        RoutingRule greaterThanRule =
+                new RoutingRule("marginPercentage", ">f", "1.00000007", "target", "label");
+
+        assertFalse(equalsRoundedFloatRule.matches(msg, null));
+        assertTrue(greaterThanRule.matches(msg, null));
+    }
+
+    @Test
+    void marginPercentageGreaterThanRuleMatchesAboveThreshold() {
+        StandardMessage msg = new StandardMessage();
+        msg.marginPercentage = 0.3300000000000001;
+
+        RoutingRule rule = new RoutingRule("marginPercentage", ">f", "0.33", "target", "label");
+
+        assertTrue(rule.matches(msg, null));
+    }
+}


### PR DESCRIPTION
Add double value access to core messages and use it for float-style routing comparisons, preserving precision for fields such as marginPercentage. Cover marginPercentage precision behavior with routing rule tests.