### PR TITLE
build: add core in dependency management

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,6 @@
         <skipUT>${skipTests}</skipUT>
         <skipIT>${skipTests}</skipIT>
 
-        <sendium.version>${project.version}</sendium.version>
         <cloudhopper.smpp.version>7.2.2</cloudhopper.smpp.version>
         <assertj.version>3.27.7</assertj.version>
         <mockito.version>5.23.0</mockito.version>
@@ -53,6 +52,12 @@
                 <version>${quarkus.platform.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
+            </dependency>
+
+            <dependency>
+                <groupId>gr.cytech</groupId>
+                <artifactId>sendium-core</artifactId>
+                <version>0.2.2-SNAPSHOT</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
this allows children to specify a single version (for the parent) and depend on core without re-specifying version