### PR TITLE
fix(release): keep sendium-core dependencyManagement version in lockstep on release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,8 @@
             <dependency>
                 <groupId>gr.cytech</groupId>
                 <artifactId>sendium-core</artifactId>
-                <version>0.2.2-SNAPSHOT</version>
+                <!-- release-please bumps this via the generic extra-files updater; the maven release-type does NOT rewrite dependencyManagement versions -->
+                <version>0.2.2</version> <!-- x-release-please-version -->
             </dependency>
 
             <dependency>

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,7 +4,13 @@
   "include-component-in-tag": false,
   "packages": {
     ".": {
-      "package-name": "sendium"
+      "package-name": "sendium",
+      "extra-files": [
+        {
+          "type": "generic",
+          "path": "pom.xml"
+        }
+      ]
     }
   },
   "plugins": [


### PR DESCRIPTION
The 0.2.2 release published a parent POM that managed gr.cytech:sendium-core at 0.2.2-SNAPSHOT instead of 0.2.2. Downstream consumers that inherit this parent and omit the sendium-core version (e.g. smsg) then tried to resolve gr.cytech:sendium-core:0.2.2-SNAPSHOT, which does not exist as a published release artifact (and would be invalid to depend on from a release even if it did), so their builds failed.

Root cause: release-please's `maven` release-type (with the maven-workspace plugin) rewrites only the project <version> and the modules' <parent> versions on release. It does NOT rewrite versions inside <dependencyManagement>. The sendium-core entry added in 57d73d6 was a plain literal, so it was never bumped away from 0.2.2-SNAPSHOT and shipped stale in the released 0.2.2 parent POM.

Fix: let release-please maintain that specific line.
- pom.xml: tag the managed sendium-core version with the inline release-please marker so the generic updater rewrites it: <version>0.2.2</version> <!-- x-release-please-version -->
- release-please-config.json: register pom.xml as an `extra-files` entry using the `generic` updater for the "." package, so the annotated line is rewritten to the release version on every release.

Expected result: the next release (0.2.3) bumps this line 0.2.2 -> 0.2.3 alongside the project version. Confirm this on the release PR diff before publishing. Once shipped, the published parent always manages sendium-core at the matching release version, so consumers (e.g. smsg) can inherit it without pinning a version of their own.