### PR TITLE
fix(DLR): Avoid creating the MVStore when the service is unused

### DIFF
--- a/sendium-core/src/main/java/gr/cytech/sendium/core/worker/InMemoryDlrService.java
+++ b/sendium-core/src/main/java/gr/cytech/sendium/core/worker/InMemoryDlrService.java
@@ -5,10 +5,9 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import gr.cytech.sendium.core.message.StandardMessage;
-import io.quarkus.runtime.ShutdownEvent;
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
 import jakarta.enterprise.context.ApplicationScoped;
-import jakarta.enterprise.event.Observes;
 import jakarta.inject.Inject;
 import org.h2.mvstore.MVStore;
 import org.slf4j.Logger;
@@ -139,7 +138,8 @@ public class InMemoryDlrService {
         logger.info("Using in-memory mode (no persistence)");
     }
 
-    void onStop(@Observes ShutdownEvent ev) {
+    @PreDestroy
+    void onStop() {
         logger.info("InMemoryDlrService shutting down");
         saveAndClose();
     }

--- a/sendium-core/src/test/java/gr/cytech/sendium/core/worker/InMemoryDlrServiceTest.java
+++ b/sendium-core/src/test/java/gr/cytech/sendium/core/worker/InMemoryDlrServiceTest.java
@@ -33,7 +33,7 @@ class InMemoryDlrServiceTest {
     @AfterEach
     void tearDown() throws Exception {
         if (dlrService != null) {
-            dlrService.onStop(null);
+            dlrService.onStop();
         }
         if (oldDbPath == null) {
             System.clearProperty("sendium.dlr.db.path");
@@ -230,7 +230,7 @@ class InMemoryDlrServiceTest {
         StandardMessage dlr = createDlr("account-restart", "sys-restart");
 
         assertTrue(dlrService.saveUnpushedDlr(dlr));
-        dlrService.onStop(null);
+        dlrService.onStop();
 
         dlrService = new InMemoryDlrService();
         dlrService.init();


### PR DESCRIPTION
InMemoryDlrService flushed and closed its H2 MVStore from an @Observes ShutdownEvent method. An event observer forces the container to instantiate the @ApplicationScoped bean in order to deliver the event, so @PostConstruct runs and opens its on-disk MVStore (creating the file) even when the DLR service is never otherwise used.

Switch the shutdown hook to @PreDestroy, which only runs for instances that were actually created and so never forces instantiation. The store is now opened (and the file created) only when the service is genuinely used, while still being flushed and closed on shutdown.