### PR TITLE
fix(core): cover StandardMessage byte JSON handling

### DIFF
--- a/sendium-core/src/test/java/gr/cytech/sendium/core/message/StandardMessageJsonResource.java
+++ b/sendium-core/src/test/java/gr/cytech/sendium/core/message/StandardMessageJsonResource.java
@@ -1,0 +1,19 @@
+package gr.cytech.sendium.core.message;
+
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/test/standard-message-json")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class StandardMessageJsonResource {
+    @POST
+    public StandardMessage echo(StandardMessageRequest request) {
+        return request.message();
+    }
+
+    public record StandardMessageRequest(StandardMessage message) {}
+}

--- a/sendium-core/src/test/java/gr/cytech/sendium/core/message/StandardMessageJsonResourceTest.java
+++ b/sendium-core/src/test/java/gr/cytech/sendium/core/message/StandardMessageJsonResourceTest.java
@@ -1,0 +1,32 @@
+package gr.cytech.sendium.core.message;
+
+import io.quarkus.test.junit.QuarkusTest;
+import org.junit.jupiter.api.Test;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.equalTo;
+
+@QuarkusTest
+class StandardMessageJsonResourceTest {
+    @Test
+    void shouldDeserializeStandardMessageWithPrimitiveByteFields() {
+        given()
+                .contentType("application/json")
+                .body("""
+                        {
+                          "message": {
+                            "from": "sender",
+                            "to": "recipient",
+                            "body": "hello",
+                            "type": 0,
+                            "dcs": 8
+                          }
+                        }
+                        """)
+                .when()
+                .post("/test/standard-message-json")
+                .then()
+                .statusCode(200)
+                .body("dcs", equalTo(8));
+    }
+}


### PR DESCRIPTION
Adds a Quarkus regression test that posts a StandardMessage with the primitive byte dcs field through REST/Jackson.