### PR TITLE
feat: add secure quick-start installer

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -9,6 +9,19 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  quick-start:
+    permissions:
+      contents: read
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+      - name: Test quick-start generator
+        run: sh tests/quick-start-test.sh
+
   tests:
     permissions:
       contents: read
@@ -28,6 +41,12 @@ jobs:
           export QUARKUS_LOG_LEVEL=ERROR
           chmod +x ./mvnw
           ./mvnw verify
+      - name: Build quick-start test image
+        run: docker build -t sendium:quick-start-test -f sendium-app/src/main/docker/Dockerfile.jvm sendium-app
+      - name: Test generated container startup
+        env:
+          SENDIUM_TEST_IMAGE: sendium:quick-start-test
+        run: sh tests/quick-start-test.sh
       - id: result
         name: Sendium Test Result
         if: always()
@@ -53,7 +72,7 @@ jobs:
         if: always()
         continue-on-error: true
   automerge-dependabot:
-    needs: tests
+    needs: [quick-start, tests]
     if: success() && github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
     runs-on: ubuntu-latest
     permissions:

--- a/README.md
+++ b/README.md
@@ -52,113 +52,57 @@ With over 20 years of experience building high-performance telecommunications so
 ## 📦 Quick Start
 
 ### Prerequisites
-* Docker installed on your host machine.
-* Create three empty directories in your current working folder: `./conf`, `./data`, and `./logs`.
-* Before starting the container, Sendium requires three configuration files inside `./conf`. These files control your binds, authentication, and routing logic.
 
-Create the following three files inside `./conf` and adapt the sample configurations:
-#### 1. credentials.yml
-- Setting smpp and http credentials on sendium
+* Docker with Docker Compose v2.
+* `curl` and a POSIX shell.
 
-```yml
-credentials:
-  - type: SMPP
-    systemId: "sendium-smpp-user"
-    password: "change-me-smpp"
-  - type: HTTP
-    systemId: "sendium-http-user"
-    password: "change-me-http"
-```
-#### 2. smsg.properties
-- Setting a smpp client connection and the smpp server.
-```properties
-# sample smpp client worker
-outSms.instance.testRoute.enable = true
-outSms.instance.testRoute.type = smppclient
-outSms.instance.testRoute.username = upstream-system-id
-outSms.instance.testRoute.password = upstream-password
-outSms.instance.testRoute.host = smpp.test.com
-outSms.instance.testRoute.port = 2775
-outSms.instance.testRoute.tps = 0
-outSms.instance.testRoute.connections.transceivers = 1
+### Generate and Start Sendium
 
-# smpp server
-outSms.instance.smpp.enable = true
-outSms.instance.smpp.type = smppserver
-outSms.instance.smpp.tps = 0
-outSms.instance.smpp.srv.port = 27777
-outSms.instance.smpp.srv.defaultWindowSize = 1000
-outSms.instance.smpp.srv.maxConnections = 1000
-outSms.instance.smpp.srv.maxConnectionsPerIP = 4
-outSms.instance.smpp.conf.maxConnectionsPerUser.default = 4
-outSms.instance.smpp.conf.maxRate.default = 0
-```
-#### 3. routingTable.conf
-- Routing configuration for sending all traffic by default through the SMPP client named `testRoute`
-
-```conf
-[default]
-MESSAGE:type:==:0
-MESSAGE:type:==:11
-MESSAGE:type:==:14
-MESSAGE:type:==:17
-MESSAGE:type:==:10
-smppserver.smpp:type:==:18
-
-[MESSAGE]
-testRoute::default:
-```
-
-### Running with Docker
-Sendium publishes two Docker image variants:
-
-| Image | Runtime |
-| :--- | :--- |
-| `cytechmobile/sendium:latest` | JVM image based on Eclipse Temurin 25 JRE. |
-| `cytechmobile/sendium:latest-native` | Native executable image. |
-
-Run the following command to start the default JVM image in the background:
+Download and run the setup script:
 
 ```bash
-docker run -d --name sendium \
-  -e QUARKUS_LOG_FILE_ENABLE=true \
-  -e QUARKUS_LOG_CONSOLE_ENABLE=false \
-  -e QUARKUS_LOG_FILE_PATH=/work/logs/smsg.log \
-  -e QUARKUS_LOG_FILE_SMPPCLIENT_PATH=/work/logs/smppclient.log \
-  -e QUARKUS_LOG_FILE_SMPPSERVER_PATH=/work/logs/smppserver.log \
-  -e QUARKUS_HTTP_ACCESS_LOG_DIRECTORY=/work/logs \
-  -p 8080:8080 \
-  -p 27777:27777 \
-  -v ./conf:/work/conf \
-  -v ./data:/work/data \
-  -v ./logs:/work/logs \
-  cytechmobile/sendium:latest
+curl -fsSLo quick-start.sh https://raw.githubusercontent.com/cytechmobile/sendium/main/quick-start.sh && sh quick-start.sh
 ```
 
-To run the native image instead, use `cytechmobile/sendium:latest-native`.
+The script creates a `sendium/` runtime directory, generates random HTTP and SMPP credentials, writes Docker Compose and all required configuration files, starts Sendium, and waits for the HTTP API.
+
+It asks you to choose one upstream option:
+
+1. **ProSMS:** Uses `smpp.prosms.gr:2775` with a transceiver connection. [Create a ProSMS account](https://prosms.gr/sms-tool/?v=2&m=8) if needed; SMPP credentials require manual approval from ProSMS. Until credentials are approved, the script creates a local-only setup without a failing placeholder connection.
+2. **Existing SMPP provider:** Enter your provider host, port, credentials, and TLS choice. Quick Start uses a transceiver connection.
+3. **Local setup only:** Starts Sendium's local HTTP and SMPP interfaces without an outbound provider. You can explore the API, but messages cannot be delivered until an upstream route is configured.
+
+HTTP and SMPP ports are bound to `127.0.0.1` by default. Use the [Docker deployment guide](docs/02-docker-deployment.md) for generated-file details, manual setup, native images, and non-local deployments.
+
+When startup completes, the script prints the Swagger URL and an exact command for following live logs
+
+### Send Your First SMS
+
+For a configured upstream provider, load the generated local HTTP credentials and submit a message:
+
+```bash
+cd sendium
+set -a
+. ./.sendium.env
+set +a
+
+curl -i -G http://127.0.0.1:8080/sendsms \
+  --data-urlencode "username=${SENDIUM_HTTP_USER}" \
+  --data-urlencode "password=${SENDIUM_HTTP_PASSWORD}" \
+  --data-urlencode "from=Sendium" \
+  --data-urlencode "to=306910000000" \
+  --data-urlencode "text=Hello from Sendium!"
+```
+
+Replace the sender and recipient with values accepted by your provider. A `202 Accepted` response and UUID mean Sendium validated and queued the request; they do not confirm that the upstream provider accepted or delivered the SMS.
+
+See the [Docker deployment guide](docs/02-docker-deployment.md) for the complete manual container setup. Configuration details are maintained in [Authentication and Security](docs/03-auth-security.md), [SMPP Configuration](docs/04-smpp-configuration.md), [Routing Engine](docs/05-routing-engine.md), and the [Configuration Reference](docs/09-configuration-reference.md).
 
 ## 💬 Documentation & Support
 
 The documentation entry point is **[docs/DocumentationMap.md](docs/DocumentationMap.md)**. It includes the recommended reading order, current docs index, runtime files, API discovery endpoints, roadmap, and community resources.
 
 Migrating from Kannel? Use the browser-only **[Kannel migration converter](https://cytechmobile.github.io/sendium/)** to paste a legacy `kannel.conf` and generate Sendium starter files locally in your browser.
-
-Key docs:
-
-1. **[Architecture Overview](docs/01-architecture.md):** Understand runtime components, queues, routing flow, workers, DLRs with diagrams.
-2. **[Docker Deployment](docs/02-docker-deployment.md):** Run Sendium with Docker, volumes, ports, logs, and startup checks.
-3. **[Authentication & Security](docs/03-auth-security.md):** Configure HTTP and SMPP credentials.
-4. **[SMPP Configuration](docs/04-smpp-configuration.md):** Configure SMPP server, SMPP client, worker behavior, TLS, retries, and logging.
-5. **[Routing Engine](docs/05-routing-engine.md):** Configure routing tables, rules, operators, and fallbacks.
-6. **[HTTP API](docs/06-http-api.md):** Submit SMS through the Kannel-compatible `/sendsms` endpoint.
-7. **[Webhooks](docs/07-webhooks.md):** Configure DLR callbacks and MO forwarding.
-8. **[Monitoring & Observability](docs/08-monitoring-observability.md):** Expose Prometheus metrics and configure Prometheus/Grafana.
-9. **[Configuration Reference](docs/09-configuration-reference.md):** Review paths, Docker environment variables, logging, and OpenAPI endpoints.
-10. **[Troubleshooting](docs/10-troubleshooting.md):** Diagnose common setup and runtime issues.
-11. **[Release Process](docs/11-release-process.md):** Understand Release Please, Maven publishing, and Docker image publishing.
-12. **[Features & Roadmap](docs/12-features-roadmap.md):** Review current capabilities and planned roadmap phases.
-
-When Sendium is running, API discovery is available at `/swagger-ui` and `/openapi.json`.
 
 If you run into issues, have questions, or want to share what you're building, we'd love to hear from you! We use **[GitHub Discussions](https://github.com/cytechmobile/sendium/discussions)** for our community hub.
 
@@ -168,5 +112,3 @@ To help us help you faster, please use the appropriate category:
 * **💡 Ideas:** Have a feature request or a suggestion to make Sendium better? Let's discuss it.
 * **🙌 Show and tell:** Are you using Sendium in production? Did you build a cool integration? Share it with the community!
 * **💬 General:** For all other chats and discussions about the project.
-
-*Note: If you are confident you have found a bug, please open a formal [GitHub Issue](https://github.com/cytechmobile/sendium/issues) so we can track it.*

--- a/docs/02-docker-deployment.md
+++ b/docs/02-docker-deployment.md
@@ -2,13 +2,70 @@
 
 This guide explains how to run Sendium with Docker for local testing or simple deployments.
 
-## Prerequisites
+## Generated Quick Start
+
+The recommended evaluation path generates random local credentials, Docker Compose, and the three required configuration files:
+
+```bash
+curl -fsSLo quick-start.sh \
+  https://raw.githubusercontent.com/cytechmobile/sendium/main/quick-start.sh
+less quick-start.sh
+sh quick-start.sh
+```
+
+Requirements:
+
+- Docker with Docker Compose v2.
+- `curl` and a POSIX shell on Linux, macOS, or WSL.
+- A WSL filesystem directory, such as a directory under `~`, if Unix secret-file permissions must be enforced. If the script's permission probe cannot enforce mode `600`, it rejects the target unless `--allow-windows-mount` is explicitly supplied.
+
+The interactive script supports:
+
+| Mode | Generated upstream behavior |
+| :--- | :--- |
+| `ProSMS` | Configures `smpp.prosms.gr:2775`, no TLS, and one transceiver after approved credentials are supplied. Without approved credentials, it links to [ProSMS registration](https://prosms.gr/sms-tool/?v=2&m=8) and generates local-only configuration. |
+| `Existing SMPP provider` | Prompts for host, port, system ID, password, and TLS, then configures one transceiver. |
+| `Local setup only` | Starts the HTTP API and local SMPP server without an outbound route. |
+
+Use `--provider local`, `--provider prosms`, or `--provider custom` to select a mode non-interactively. Run `sh quick-start.sh --help` for supported environment variables and all options.
+
+The default generated layout is:
+
+```text
+sendium/
+  .sendium.env
+  compose.yml
+  conf/
+    credentials.yml
+    smsg.properties
+    routingTable.conf
+  data/
+  logs/
+```
+
+`.sendium.env`, `credentials.yml`, and `smsg.properties` contain secrets. The generated `.gitignore` excludes them, but they still require access-controlled storage and backups.
+
+Using `--force` regenerates the local credentials and configuration. When startup is enabled, Quick Start recreates the container so the new credentials and worker configuration take effect together. With `--no-start`, it prints the required `docker compose up -d --force-recreate` command instead.
+
+To generate a separate runtime using the native image, first stop any generated runtime using the same local ports:
+
+```bash
+docker compose -f sendium/compose.yml --project-directory sendium down
+
+sh quick-start.sh \
+  --directory sendium-native \
+  --image cytechmobile/sendium:latest-native
+```
+
+## Manual Deployment
+
+### Prerequisites
 
 - Docker installed on the host machine.
 - A working directory with `conf`, `data`, and `logs` subdirectories.
 - The required configuration files inside `conf`: `credentials.yml`, `smsg.properties`, and `routingTable.conf`.
 
-## Directory Layout
+### Directory Layout
 
 ```text
 sendium-runtime/
@@ -20,7 +77,7 @@ sendium-runtime/
   logs/
 ```
 
-## Ports
+### Ports
 
 | Port | Purpose |
 | :--- | :--- |
@@ -28,8 +85,9 @@ sendium-runtime/
 | `27777` | Example SMPP server port from the README quick start. |
 
 The SMPP port depends on `outSms.instance.<name>.srv.port` in `smsg.properties`.
+Set `outSms.instance.<name>.srv.host = 0.0.0.0` inside the container for the Docker port mapping to reach the SMPP server. The host-side example below still limits access to loopback.
 
-## Volumes
+### Volumes
 
 | Host path | Container path | Purpose |
 | :--- | :--- | :--- |
@@ -37,7 +95,7 @@ The SMPP port depends on `outSms.instance.<name>.srv.port` in `smsg.properties`.
 | `./data` | `/work/data` | Local runtime data. |
 | `./logs` | `/work/logs` | Application, SMPP, and HTTP access logs. |
 
-## Docker Images
+### Docker Images
 
 Sendium publishes two Docker image variants:
 
@@ -46,7 +104,7 @@ Sendium publishes two Docker image variants:
 | `cytechmobile/sendium:latest` | JVM image based on Eclipse Temurin 25 JRE. |
 | `cytechmobile/sendium:latest-native` | Native executable image. |
 
-## Run Command
+### Run Command
 
 This command starts the default JVM image:
 
@@ -58,8 +116,8 @@ docker run -d --name sendium \
   -e QUARKUS_LOG_FILE_SMPPCLIENT_PATH=/work/logs/smppclient.log \
   -e QUARKUS_LOG_FILE_SMPPSERVER_PATH=/work/logs/smppserver.log \
   -e QUARKUS_HTTP_ACCESS_LOG_DIRECTORY=/work/logs \
-  -p 8080:8080 \
-  -p 27777:27777 \
+  -p 127.0.0.1:8080:8080 \
+  -p 127.0.0.1:27777:27777 \
   -v ./conf:/work/conf \
   -v ./data:/work/data \
   -v ./logs:/work/logs \
@@ -92,8 +150,19 @@ After starting the container:
 - Map `logs` to persistent storage if logs are required after container replacement.
 - Review `QUARKUS_LOG_CONSOLE_ENABLE` and `QUARKUS_LOG_FILE_ENABLE` based on your logging stack.
 - When exposing SMPP externally, firewall the port and configure credential IP allowlists where possible.
+- Before exposing HTTP externally, terminate HTTPS at a trusted proxy and configure every proxy/access-log layer to omit query strings because `/sendsms` carries credentials and message data in its URL.
+- Before exposing SMPP externally, configure SMPP TLS or another appropriately protected private transport rather than publishing the plaintext example port.
 
 ## Stop And Remove
+
+For a generated Docker Compose runtime, run these commands inside its directory:
+
+```bash
+docker compose logs -f
+docker compose down
+```
+
+For the manual `docker run` example:
 
 ```bash
 docker stop sendium

--- a/docs/06-http-api.md
+++ b/docs/06-http-api.md
@@ -57,7 +57,7 @@ The API returns standard HTTP status codes along with a plain-text response body
 
 | HTTP Status | Meaning | Description |
 | :--- | :--- | :--- |
-| **`202 Accepted`** | **Success** | The message was successfully validated and enqueued for delivery. The response body contains the unique UUID (serial) of the message. |
+| **`202 Accepted`** | **Success** | The message was validated and inserted into Sendium's router queue. The response body contains the unique UUID (serial) of the message. |
 | **`400 Bad Request`** | **Error** | Missing a required parameter (`to`, `from`, or `text`). The response body details which parameter is missing. |
 | **`401 Unauthorized`** | **Error** | Invalid or missing credentials. |
 | **`500 Server Error`** | **Error** | An internal error occurred while parsing or processing the message payload. |
@@ -67,21 +67,30 @@ The API returns standard HTTP status codes along with a plain-text response body
 
 ## 📖 Example Request
 
-Here is an example of submitting a standard text message using `curl`:
+If you used the generated Quick Start and configured an upstream provider, load its HTTP credentials before submitting a message:
 
 ```bash
-curl -G http://localhost:8080/sendsms \
-  --data-urlencode "username=myuser" \
-  --data-urlencode "password=example-password" \
+cd sendium
+set -a
+. ./.sendium.env
+set +a
+
+curl -i -G http://127.0.0.1:8080/sendsms \
+  --data-urlencode "username=${SENDIUM_HTTP_USER}" \
+  --data-urlencode "password=${SENDIUM_HTTP_PASSWORD}" \
   --data-urlencode "from=Sendium" \
   --data-urlencode "to=306910000000" \
   --data-urlencode "text=Hello from Sendium!"
 ```
 
+For a manual installation, replace the environment variables with the HTTP `systemId` and `password` from `credentials.yml`. Keep the endpoint local for evaluation. Before external use, terminate HTTPS at a trusted proxy and ensure proxy/access logs omit query strings because authentication credentials, addresses, and message content are URL parameters.
+
 **Example Successful Response (`202 Accepted`):**
 ```text
 123e4567-e89b-12d3-a456-426614174000
 ```
+
+`202 Accepted` means Sendium validated the message and inserted it into the router queue. It does not prove that a viable route exists, that an upstream SMSC accepted the message, or that a handset received it. Local-only Quick Start installations have no outbound route. Check routing configuration, the SMPP client connection, message lifecycle logs, submit response, and delivery receipt for those later stages.
 
 ## Related Documentation
 

--- a/quick-start.sh
+++ b/quick-start.sh
@@ -1,0 +1,599 @@
+#!/bin/sh
+
+set -eu
+
+DEFAULT_TARGET_DIR="sendium"
+DEFAULT_IMAGE="cytechmobile/sendium:latest"
+PROSMS_HOST="smpp.prosms.gr"
+PROSMS_PORT="2775"
+PROSMS_REGISTRATION_URL="https://prosms.gr/sms-tool/?v=2&m=8"
+
+target_dir=$DEFAULT_TARGET_DIR
+image=$DEFAULT_IMAGE
+start_sendium=true
+force=false
+provider=''
+allow_windows_mount=false
+upstream_password_from_environment=${SENDIUM_UPSTREAM_PASSWORD-}
+unset SENDIUM_UPSTREAM_PASSWORD
+
+usage() {
+    cat <<'EOF'
+Usage: ./quick-start.sh [options]
+
+Generate a local Sendium runtime and start it with Docker Compose.
+
+Options:
+  --directory DIR  Output directory (default: sendium)
+  --image IMAGE    Docker image (default: cytechmobile/sendium:latest)
+  --provider MODE  Provider mode: local, prosms, or custom
+  --allow-windows-mount
+                  Allow secrets on a WSL-mounted Windows directory
+  --no-start       Generate files without starting Sendium
+  --force          Replace generated files in a non-empty output directory
+  -h, --help       Show this help
+
+Non-interactive provider configuration:
+  Set SENDIUM_UPSTREAM_USERNAME and SENDIUM_UPSTREAM_PASSWORD for ProSMS.
+  Custom SMPP also uses SENDIUM_UPSTREAM_HOST, SENDIUM_UPSTREAM_PORT,
+  and SENDIUM_UPSTREAM_TLS.
+EOF
+}
+
+fail() {
+    printf 'Error: %s\n' "$*" >&2
+    exit 1
+}
+
+require_value() {
+    option=$1
+    value=${2-}
+    [ -n "$value" ] || fail "$option requires a value"
+}
+
+generate_secret() {
+    byte_count=$1
+    secret=''
+
+    if [ -r /dev/urandom ] && command -v od >/dev/null 2>&1; then
+        secret=$(LC_ALL=C od -An -N "$byte_count" -tx1 /dev/urandom | tr -d ' \n')
+    elif command -v openssl >/dev/null 2>&1; then
+        secret=$(openssl rand -hex "$byte_count")
+    fi
+
+    expected_length=$((byte_count * 2))
+    [ "${#secret}" -eq "$expected_length" ] || fail "could not generate a secure random password"
+    printf '%s' "$secret"
+}
+
+generate_smpp_secret() {
+    secret=''
+
+    if [ -r /dev/urandom ] && command -v tr >/dev/null 2>&1 && command -v dd >/dev/null 2>&1; then
+        # Bound the input so tr reaches EOF even when SIGPIPE is ignored.
+        secret=$(dd if=/dev/urandom bs=256 count=1 2>/dev/null | LC_ALL=C tr -dc 'A-Za-z0-9' | dd bs=1 count=8 2>/dev/null)
+    elif command -v openssl >/dev/null 2>&1; then
+        secret=$(openssl rand -base64 12 | LC_ALL=C tr -dc 'A-Za-z0-9' | dd bs=1 count=8 2>/dev/null)
+    fi
+
+    [ "${#secret}" -eq 8 ] || fail "could not generate a secure random SMPP password"
+    printf '%s' "$secret"
+}
+
+prompt_value() {
+    prompt=$1
+    default_value=${2-}
+
+    if [ -n "$default_value" ]; then
+        printf '%s [%s]: ' "$prompt" "$default_value" >&2
+    else
+        printf '%s: ' "$prompt" >&2
+    fi
+
+    if ! IFS= read -r REPLY; then
+        fail "could not read interactive input"
+    fi
+    if [ -z "$REPLY" ]; then
+        REPLY=$default_value
+    fi
+}
+
+prompt_secret() {
+    prompt=$1
+    printf '%s: ' "$prompt" >&2
+    terminal_state=$(stty -g) || fail "could not read terminal settings"
+    trap 'stty "$terminal_state" 2>/dev/null || true; exit 130' HUP INT TERM
+    stty -echo
+    if ! IFS= read -r REPLY; then
+        stty "$terminal_state"
+        trap - HUP INT TERM
+        fail "could not read interactive input"
+    fi
+    stty "$terminal_state"
+    trap - HUP INT TERM
+    printf '\n' >&2
+}
+
+is_yes() {
+    case "$1" in
+        y|Y|yes|YES|Yes|true|TRUE|True)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+validate_property_value() {
+    label=$1
+    property_value=$2
+    [ -n "$property_value" ] || fail "$label cannot be empty"
+    property_value_without_line_breaks=$(printf '%s' "$property_value" | LC_ALL=C tr -d '\r\n')
+    if [ "$property_value" != "$property_value_without_line_breaks" ]; then
+        fail "$label cannot contain control characters"
+    fi
+    if printf '%s' "$property_value" | LC_ALL=C grep -q '[[:cntrl:]]'; then
+        fail "$label cannot contain control characters"
+    fi
+    case "$property_value" in
+        ' '*|*' ')
+            fail "$label cannot start or end with a space"
+            ;;
+    esac
+}
+
+validate_smpp_credential() {
+    label=$1
+    credential_value=$2
+    maximum_bytes=$3
+    validate_property_value "$label" "$credential_value"
+
+    if printf '%s' "$credential_value" | LC_ALL=C grep -q '[^ -~]'; then
+        fail "$label must contain printable ASCII characters only"
+    fi
+
+    credential_bytes=$(printf '%s' "$credential_value" | LC_ALL=C wc -c | tr -d ' ')
+    [ "$credential_bytes" -le "$maximum_bytes" ] || fail "$label must not exceed $maximum_bytes bytes"
+}
+
+escape_property_value() {
+    printf '%s' "$1" | sed 's/\\/\\\\/g'
+}
+
+validate_port() {
+    port_value=$1
+    case "$port_value" in
+        ''|*[!0-9]*)
+            fail "SMPP port must be a number"
+            ;;
+    esac
+    [ "$port_value" -ge 1 ] && [ "$port_value" -le 65535 ] || fail "SMPP port must be between 1 and 65535"
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --directory)
+            require_value "$1" "${2-}"
+            target_dir=$2
+            shift 2
+            ;;
+        --image)
+            require_value "$1" "${2-}"
+            image=$2
+            shift 2
+            ;;
+        --provider)
+            require_value "$1" "${2-}"
+            provider=$2
+            shift 2
+            ;;
+        --allow-windows-mount)
+            allow_windows_mount=true
+            shift
+            ;;
+        --no-start)
+            start_sendium=false
+            shift
+            ;;
+        --force)
+            force=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            fail "unknown option: $1"
+            ;;
+    esac
+done
+
+[ -n "$target_dir" ] || fail "output directory cannot be empty"
+[ -n "$image" ] || fail "Docker image cannot be empty"
+
+if [ -L "$target_dir" ]; then
+    fail "output directory cannot be a symbolic link: $target_dir"
+fi
+
+if [ -e "$target_dir" ] && [ ! -d "$target_dir" ]; then
+    fail "output path exists and is not a directory: $target_dir"
+fi
+
+if [ -d "$target_dir" ] && [ -n "$(ls -A "$target_dir" 2>/dev/null)" ] && [ "$force" != true ]; then
+    fail "output directory is not empty: $target_dir (use --force to replace generated files)"
+fi
+
+if [ "$start_sendium" = true ]; then
+    command -v docker >/dev/null 2>&1 || fail "Docker is required unless --no-start is used"
+    docker compose version >/dev/null 2>&1 || fail "Docker Compose v2 is required"
+    docker info >/dev/null 2>&1 || fail "Docker is not running or is not accessible"
+    command -v curl >/dev/null 2>&1 || fail "curl is required for the startup check"
+fi
+
+umask 077
+mkdir -p "$target_dir"
+absolute_target=$(cd "$target_dir" && pwd -P)
+windows_mount_insecure=false
+
+case "$(uname -r 2>/dev/null || true)" in
+    *[Mm]icrosoft*)
+        permission_probe=$(mktemp "$target_dir/.quick-start-permission-check.XXXXXX") || fail "could not test target directory permissions"
+        chmod 600 "$permission_probe"
+        permission_mode=$(stat -c %a "$permission_probe")
+        rm -f "$permission_probe"
+        if [ "$permission_mode" != 600 ]; then
+            windows_mount_insecure=true
+            if [ "$allow_windows_mount" != true ]; then
+                fail "WSL cannot enforce Unix secret-file modes in $absolute_target; use a directory under your WSL home or pass --allow-windows-mount"
+            fi
+        fi
+        ;;
+esac
+
+for runtime_dir in conf data logs; do
+    if [ -L "$target_dir/$runtime_dir" ]; then
+        fail "generated directory cannot be a symbolic link: $target_dir/$runtime_dir"
+    fi
+    if [ -e "$target_dir/$runtime_dir" ] && [ ! -d "$target_dir/$runtime_dir" ]; then
+        fail "generated directory path is not a directory: $target_dir/$runtime_dir"
+    fi
+done
+
+for generated_file in .sendium.env .gitignore compose.yml conf/credentials.yml conf/smsg.properties conf/routingTable.conf; do
+    if [ -L "$target_dir/$generated_file" ]; then
+        fail "generated file cannot be a symbolic link: $target_dir/$generated_file"
+    fi
+    if [ -e "$target_dir/$generated_file" ] && [ ! -f "$target_dir/$generated_file" ]; then
+        fail "generated file path is not a regular file: $target_dir/$generated_file"
+    fi
+done
+
+interactive=false
+if [ -t 0 ]; then
+    interactive=true
+fi
+
+if [ -z "$provider" ]; then
+    if [ "$interactive" = true ]; then
+        printf '\nChoose an upstream SMS provider:\n' >&2
+        printf '  1. ProSMS\n' >&2
+        printf '  2. Existing SMPP provider\n' >&2
+        printf '  3. Local setup only\n' >&2
+        prompt_value "Selection" "3"
+        case "$REPLY" in
+            1) provider='prosms' ;;
+            2) provider='custom' ;;
+            3) provider='local' ;;
+            *) fail "provider selection must be 1, 2, or 3" ;;
+        esac
+    else
+        provider='local'
+    fi
+fi
+
+case "$provider" in
+    local|prosms|custom) ;;
+    *) fail "provider must be local, prosms, or custom" ;;
+esac
+
+upstream_enabled=false
+prosms_pending=false
+upstream_host=''
+upstream_port=''
+upstream_username=${SENDIUM_UPSTREAM_USERNAME-}
+upstream_password=$upstream_password_from_environment
+upstream_password_from_environment=''
+upstream_tls='false'
+
+if [ "$provider" = prosms ]; then
+    upstream_host=$PROSMS_HOST
+    upstream_port=$PROSMS_PORT
+
+    if [ -n "$upstream_username" ] || [ -n "$upstream_password" ]; then
+        [ -n "$upstream_username" ] && [ -n "$upstream_password" ] || fail "both ProSMS username and password must be provided"
+        upstream_enabled=true
+    elif [ "$interactive" = true ]; then
+        prompt_value "Do you already have approved ProSMS SMPP credentials? (y/N)" "N"
+        if is_yes "$REPLY"; then
+            prompt_value "ProSMS SMPP username" ""
+            upstream_username=$REPLY
+            prompt_secret "ProSMS SMPP password"
+            upstream_password=$REPLY
+            upstream_enabled=true
+        else
+            prosms_pending=true
+        fi
+    else
+        prosms_pending=true
+    fi
+fi
+
+if [ "$provider" = custom ]; then
+    upstream_host=${SENDIUM_UPSTREAM_HOST-}
+    upstream_port=${SENDIUM_UPSTREAM_PORT-2775}
+    upstream_tls=${SENDIUM_UPSTREAM_TLS-false}
+
+    if [ "$interactive" = true ]; then
+        prompt_value "SMPP host" "$upstream_host"
+        upstream_host=$REPLY
+        prompt_value "SMPP port" "$upstream_port"
+        upstream_port=$REPLY
+        prompt_value "SMPP username" "$upstream_username"
+        upstream_username=$REPLY
+        if [ -z "$upstream_password" ]; then
+            prompt_secret "SMPP password"
+            upstream_password=$REPLY
+        fi
+        prompt_value "Use TLS? (y/N)" "$upstream_tls"
+        if is_yes "$REPLY"; then
+            upstream_tls='true'
+        else
+            upstream_tls='false'
+        fi
+    fi
+
+    [ -n "$upstream_host" ] || fail "custom SMPP requires SENDIUM_UPSTREAM_HOST or interactive input"
+    [ -n "$upstream_username" ] || fail "custom SMPP requires SENDIUM_UPSTREAM_USERNAME or interactive input"
+    [ -n "$upstream_password" ] || fail "custom SMPP requires SENDIUM_UPSTREAM_PASSWORD or interactive input"
+    upstream_enabled=true
+fi
+
+if [ "$upstream_enabled" = true ]; then
+    validate_property_value "SMPP host" "$upstream_host"
+    validate_port "$upstream_port"
+    validate_smpp_credential "SMPP username" "$upstream_username" 15
+    validate_smpp_credential "SMPP password" "$upstream_password" 8
+
+    case "$upstream_tls" in
+        true|false) ;;
+        *) fail "SMPP TLS must be true or false" ;;
+    esac
+
+    upstream_host=$(escape_property_value "$upstream_host")
+    upstream_username=$(escape_property_value "$upstream_username")
+    upstream_password=$(escape_property_value "$upstream_password")
+fi
+
+mkdir -p "$target_dir/conf" "$target_dir/data" "$target_dir/logs"
+staging_dir=$(mktemp -d "$target_dir/.quick-start.XXXXXX") || fail "could not create a staging directory"
+mkdir -p "$staging_dir/conf"
+install_started=false
+install_complete=false
+backup_dir="$staging_dir/backup"
+
+cleanup_quick_start() {
+    if [ "$install_started" = true ] && [ "$install_complete" = false ]; then
+        for generated_file in .sendium.env .gitignore compose.yml conf/credentials.yml conf/smsg.properties conf/routingTable.conf; do
+            if [ -f "$backup_dir/$generated_file" ]; then
+                mv -f "$backup_dir/$generated_file" "$target_dir/$generated_file"
+            else
+                rm -f "$target_dir/$generated_file"
+            fi
+        done
+    fi
+    if [ -d "$staging_dir" ]; then
+        rm -rf "$staging_dir"
+    fi
+}
+trap cleanup_quick_start 0
+
+http_user='sendium-http'
+smpp_user='sendium-smpp'
+http_password=$(generate_secret 24)
+# SMPP 3.4 bind passwords are limited to eight characters.
+smpp_password=$(generate_smpp_secret)
+
+cat > "$staging_dir/.sendium.env" <<EOF
+SENDIUM_HTTP_USER='$http_user'
+SENDIUM_HTTP_PASSWORD='$http_password'
+SENDIUM_SMPP_USER='$smpp_user'
+SENDIUM_SMPP_PASSWORD='$smpp_password'
+EOF
+
+cat > "$staging_dir/.gitignore" <<'EOF'
+.sendium.env
+conf/credentials.yml
+conf/smsg.properties
+data/
+logs/
+EOF
+
+cat > "$staging_dir/conf/credentials.yml" <<EOF
+credentials:
+  - type: SMPP
+    accountId: "quickstart-smpp"
+    systemId: "$smpp_user"
+    password: "$smpp_password"
+  - type: HTTP
+    accountId: "quickstart-http"
+    systemId: "$http_user"
+    password: "$http_password"
+EOF
+
+cat > "$staging_dir/conf/smsg.properties" <<'EOF'
+# Local SMPP server for downstream clients.
+outSms.instance.smpp.enable = true
+outSms.instance.smpp.type = smppserver
+outSms.instance.smpp.tps = 0
+outSms.instance.smpp.print.msgs = false
+outSms.instance.smpp.srv.host = 0.0.0.0
+outSms.instance.smpp.srv.port = 27777
+outSms.instance.smpp.srv.maxConnections = 1000
+outSms.instance.smpp.srv.maxConnectionsPerIP = 4
+outSms.instance.smpp.conf.maxPending.default = 1000
+outSms.instance.smpp.conf.maxConnectionsPerUser.default = 4
+outSms.instance.smpp.conf.maxRate.default = 0
+EOF
+
+if [ "$upstream_enabled" = true ]; then
+    cat >> "$staging_dir/conf/smsg.properties" <<EOF
+
+# Upstream SMPP provider.
+outSms.instance.upstream.enable = true
+outSms.instance.upstream.type = smppclient
+outSms.instance.upstream.host = $upstream_host
+outSms.instance.upstream.port = $upstream_port
+outSms.instance.upstream.username = $upstream_username
+outSms.instance.upstream.password = $upstream_password
+outSms.instance.upstream.ssl = $upstream_tls
+outSms.instance.upstream.tps = 0
+outSms.instance.upstream.connections.transceivers = 1
+outSms.instance.upstream.connections.transmitters = 0
+EOF
+fi
+
+cat > "$staging_dir/conf/routingTable.conf" <<'EOF'
+[default]
+MESSAGE:type:==:0
+MESSAGE:type:==:11
+MESSAGE:type:==:14
+MESSAGE:type:==:17
+MESSAGE:type:==:10
+smppserver.smpp:type:==:18
+
+# An upstream provider route is added when provider configuration is selected.
+[MESSAGE]
+EOF
+
+if [ "$upstream_enabled" = true ]; then
+    printf 'upstream::default:\n' >> "$staging_dir/conf/routingTable.conf"
+fi
+
+cat > "$staging_dir/compose.yml" <<EOF
+services:
+  sendium:
+    image: $image
+    environment:
+      QUARKUS_LOG_FILE_ENABLE: "true"
+      QUARKUS_LOG_CONSOLE_ENABLE: "true"
+      QUARKUS_LOG_FILE_PATH: /work/logs/smsg.log
+      QUARKUS_LOG_FILE_SMPPCLIENT_PATH: /work/logs/smppclient.log
+      QUARKUS_LOG_FILE_SMPPSERVER_PATH: /work/logs/smppserver.log
+      QUARKUS_HTTP_ACCESS_LOG_DIRECTORY: /work/logs
+    ports:
+      - "127.0.0.1:8080:8080"
+      - "127.0.0.1:27777:27777"
+    volumes:
+      - ./conf:/work/conf
+      - ./data:/work/data
+      - ./logs:/work/logs
+EOF
+
+chmod 600 \
+    "$staging_dir/.sendium.env" \
+    "$staging_dir/.gitignore" \
+    "$staging_dir/compose.yml" \
+    "$staging_dir/conf/credentials.yml" \
+    "$staging_dir/conf/smsg.properties" \
+    "$staging_dir/conf/routingTable.conf"
+
+mkdir -p "$backup_dir/conf"
+for generated_file in .sendium.env .gitignore compose.yml conf/credentials.yml conf/smsg.properties conf/routingTable.conf; do
+    if [ -f "$target_dir/$generated_file" ]; then
+        cp -p "$target_dir/$generated_file" "$backup_dir/$generated_file"
+    fi
+done
+
+if [ "$force" = true ] && [ "$start_sendium" = true ] && [ -f "$target_dir/compose.yml" ]; then
+    existing_container=$(docker compose -f "$absolute_target/compose.yml" --project-directory "$absolute_target" ps -q sendium)
+    if [ -n "$existing_container" ]; then
+        printf '\nStopping the existing Sendium container before replacing its configuration...\n'
+        docker compose -f "$absolute_target/compose.yml" --project-directory "$absolute_target" stop sendium
+    fi
+fi
+
+install_started=true
+
+mv -f "$staging_dir/.sendium.env" "$target_dir/.sendium.env"
+mv -f "$staging_dir/.gitignore" "$target_dir/.gitignore"
+mv -f "$staging_dir/compose.yml" "$target_dir/compose.yml"
+mv -f "$staging_dir/conf/credentials.yml" "$target_dir/conf/credentials.yml"
+mv -f "$staging_dir/conf/smsg.properties" "$target_dir/conf/smsg.properties"
+mv -f "$staging_dir/conf/routingTable.conf" "$target_dir/conf/routingTable.conf"
+
+chmod 600 \
+    "$target_dir/.sendium.env" \
+    "$target_dir/.gitignore" \
+    "$target_dir/compose.yml" \
+    "$target_dir/conf/credentials.yml" \
+    "$target_dir/conf/smsg.properties" \
+    "$target_dir/conf/routingTable.conf"
+
+install_complete=true
+rm -rf "$staging_dir"
+trap - 0
+
+printf '\nSendium runtime generated in %s\n' "$absolute_target"
+printf 'Local credentials: %s\n' "$absolute_target/.sendium.env"
+
+if [ "$upstream_enabled" = true ]; then
+    printf 'Upstream provider: %s (%s:%s)\n' "$provider" "$upstream_host" "$upstream_port"
+elif [ "$prosms_pending" = true ]; then
+    printf '\nProSMS requires manual approval before SMPP credentials are issued.\n'
+    printf 'Register or check your account at: %s\n' "$PROSMS_REGISTRATION_URL"
+    printf 'After approval, rerun with --provider prosms and --force.\n'
+else
+    printf 'Upstream provider: none (local setup only)\n'
+fi
+
+if [ "$windows_mount_insecure" = true ]; then
+    printf 'Warning: Unix file modes are not enforced on this WSL-mounted Windows directory.\n' >&2
+fi
+
+if [ "$start_sendium" != true ]; then
+    if [ "$force" = true ]; then
+        printf '\nRecreate Sendium later to apply the regenerated configuration and credentials:\n'
+        printf '  docker compose -f "%s/compose.yml" --project-directory "%s" up -d --force-recreate\n' "$absolute_target" "$absolute_target"
+    else
+        printf '\nStart Sendium later with:\n'
+        printf '  docker compose -f "%s/compose.yml" --project-directory "%s" up -d\n' "$absolute_target" "$absolute_target"
+    fi
+    exit 0
+fi
+
+if [ "$force" = true ]; then
+    printf '\nRecreating Sendium to apply the regenerated configuration and credentials...\n'
+    docker compose -f "$absolute_target/compose.yml" --project-directory "$absolute_target" up -d --force-recreate
+else
+    printf '\nStarting Sendium...\n'
+    docker compose -f "$absolute_target/compose.yml" --project-directory "$absolute_target" up -d
+fi
+
+attempt=0
+while [ "$attempt" -lt 60 ]; do
+    if curl -fsS --connect-timeout 2 --max-time 3 http://127.0.0.1:8080/openapi.json >/dev/null 2>&1; then
+        printf '\nSendium is ready.\n'
+        printf 'Swagger UI: http://127.0.0.1:8080/swagger-ui\n'
+        printf '\nFollow live logs with:\n'
+        printf '  docker compose -f "%s/compose.yml" --project-directory "%s" logs -f\n' "$absolute_target" "$absolute_target"
+        exit 0
+    fi
+    attempt=$((attempt + 1))
+    sleep 1
+done
+
+printf '\nSendium did not become ready. Recent container logs:\n' >&2
+docker compose -f "$absolute_target/compose.yml" --project-directory "$absolute_target" logs --tail 100 >&2 || true
+fail "startup check timed out; generated files were kept in $absolute_target"

--- a/tests/quick-start-test.sh
+++ b/tests/quick-start-test.sh
@@ -1,0 +1,261 @@
+#!/bin/sh
+
+set -eu
+
+script_dir=$(CDPATH= cd "$(dirname "$0")" && pwd -P)
+repo_dir=$(CDPATH= cd "$script_dir/.." && pwd -P)
+quick_start="$repo_dir/quick-start.sh"
+test_root=$(mktemp -d "${TMPDIR:-/tmp}/sendium-quick-start-test.XXXXXX")
+integration_dir=''
+integration_project=''
+tests_run=0
+
+cleanup() {
+    if [ -n "$integration_dir" ] && [ -f "$integration_dir/compose.yml" ] && command -v docker >/dev/null 2>&1; then
+        docker compose -p "$integration_project" -f "$integration_dir/compose.yml" --project-directory "$integration_dir" down >/dev/null 2>&1 || true
+    fi
+    rm -rf "$test_root"
+}
+trap cleanup 0
+
+fail() {
+    printf 'FAIL: %s\n' "$*" >&2
+    exit 1
+}
+
+pass() {
+    tests_run=$((tests_run + 1))
+    printf 'ok %s - %s\n' "$tests_run" "$1"
+}
+
+assert_file() {
+    [ -f "$1" ] || fail "expected file: $1"
+}
+
+assert_contains() {
+    expected=$1
+    file=$2
+    grep -F "$expected" "$file" >/dev/null 2>&1 || fail "expected '$expected' in $file"
+}
+
+assert_not_contains() {
+    unexpected=$1
+    file=$2
+    if grep -F "$unexpected" "$file" >/dev/null 2>&1; then
+        fail "did not expect '$unexpected' in $file"
+    fi
+}
+
+assert_equals() {
+    expected=$1
+    actual=$2
+    label=$3
+    [ "$expected" = "$actual" ] || fail "$label: expected '$expected', got '$actual'"
+}
+
+file_mode() {
+    stat -c %a "$1" 2>/dev/null || stat -f %Lp "$1"
+}
+
+credential_value() {
+    credential_type=$1
+    credential_key=$2
+    credential_file=$3
+    awk -v type="$credential_type" -v key="$credential_key" '
+        $0 ~ "- type: " type { in_credential = 1; next }
+        in_credential && $1 == key ":" {
+            value = $0
+            sub(/^[^:]*:[[:space:]]*"/, "", value)
+            sub(/"[[:space:]]*$/, "", value)
+            print value
+            exit
+        }
+        in_credential && /- type:/ { exit }
+    ' "$credential_file"
+}
+
+expect_failure() {
+    label=$1
+    output=$2
+    shift 2
+    if "$@" > "$output" 2>&1; then
+        fail "$label unexpectedly succeeded"
+    fi
+}
+
+sh -n "$quick_start"
+pass "POSIX shell syntax"
+
+local_dir="$test_root/local"
+sh "$quick_start" --directory "$local_dir" --provider local --no-start > "$test_root/local.out" 2>&1
+assert_file "$local_dir/compose.yml"
+assert_file "$local_dir/.sendium.env"
+assert_file "$local_dir/conf/credentials.yml"
+assert_file "$local_dir/conf/smsg.properties"
+assert_file "$local_dir/conf/routingTable.conf"
+assert_contains '127.0.0.1:8080:8080' "$local_dir/compose.yml"
+assert_contains '127.0.0.1:27777:27777' "$local_dir/compose.yml"
+assert_not_contains 'outSms.instance.upstream' "$local_dir/conf/smsg.properties"
+assert_not_contains 'upstream::default:' "$local_dir/conf/routingTable.conf"
+assert_equals 600 "$(file_mode "$local_dir/.sendium.env")" ".sendium.env mode"
+assert_equals 600 "$(file_mode "$local_dir/conf/credentials.yml")" "credentials.yml mode"
+
+http_user=$(sed -n "s/^SENDIUM_HTTP_USER='\([^']*\)'$/\1/p" "$local_dir/.sendium.env")
+http_password=$(sed -n "s/^SENDIUM_HTTP_PASSWORD='\([0-9a-f][0-9a-f]*\)'$/\1/p" "$local_dir/.sendium.env")
+smpp_user=$(sed -n "s/^SENDIUM_SMPP_USER='\([^']*\)'$/\1/p" "$local_dir/.sendium.env")
+smpp_password=$(sed -n "s/^SENDIUM_SMPP_PASSWORD='\([A-Za-z0-9][A-Za-z0-9]*\)'$/\1/p" "$local_dir/.sendium.env")
+assert_equals 'sendium-http' "$http_user" "HTTP environment username"
+assert_equals 'sendium-smpp' "$smpp_user" "SMPP environment username"
+assert_equals 48 "${#http_password}" "HTTP password length"
+assert_equals 8 "${#smpp_password}" "SMPP password length"
+assert_equals "$http_user" "$(credential_value HTTP systemId "$local_dir/conf/credentials.yml")" "HTTP credential username"
+assert_equals "$http_password" "$(credential_value HTTP password "$local_dir/conf/credentials.yml")" "HTTP credential password"
+assert_equals "$smpp_user" "$(credential_value SMPP systemId "$local_dir/conf/credentials.yml")" "SMPP credential username"
+assert_equals "$smpp_password" "$(credential_value SMPP password "$local_dir/conf/credentials.yml")" "SMPP credential password"
+pass "secure local-only generation"
+
+expect_failure "non-empty target protection" "$test_root/non-empty.out" \
+    sh "$quick_start" --directory "$local_dir" --provider local --no-start
+assert_contains 'output directory is not empty' "$test_root/non-empty.out"
+pass "non-empty target protection"
+
+printf 'keep me\n' > "$local_dir/user-file.txt"
+old_http_password=$http_password
+sh "$quick_start" --directory "$local_dir" --provider local --force --no-start > "$test_root/force.out" 2>&1
+assert_file "$local_dir/user-file.txt"
+assert_contains 'keep me' "$local_dir/user-file.txt"
+assert_contains 'up -d --force-recreate' "$test_root/force.out"
+http_password=$(sed -n "s/^SENDIUM_HTTP_PASSWORD='\([0-9a-f][0-9a-f]*\)'$/\1/p" "$local_dir/.sendium.env")
+[ -n "$http_password" ] || fail "forced regeneration did not produce an HTTP password"
+assert_equals 48 "${#http_password}" "regenerated HTTP password length"
+[ "$old_http_password" != "$http_password" ] || fail "forced regeneration did not rotate the HTTP password"
+pass "explicit regeneration preserves unrelated files"
+
+regenerated_dir="$test_root/regenerated-upstream"
+sh "$quick_start" --directory "$regenerated_dir" --provider local --no-start > "$test_root/regenerated-local.out" 2>&1
+SENDIUM_UPSTREAM_USERNAME='prosms-user' \
+SENDIUM_UPSTREAM_PASSWORD='pass1234' \
+    sh "$quick_start" --directory "$regenerated_dir" --provider prosms --force --no-start > "$test_root/regenerated-force.out" 2>&1
+assert_contains 'outSms.instance.upstream.enable = true' "$regenerated_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.type = smppclient' "$regenerated_dir/conf/smsg.properties"
+assert_not_contains 'outSms.instance.upstream.enable = false' "$regenerated_dir/conf/smsg.properties"
+assert_contains 'up -d --force-recreate' "$test_root/regenerated-force.out"
+pass "forced regeneration requires container recreation"
+
+pending_dir="$test_root/prosms-pending"
+sh "$quick_start" --directory "$pending_dir" --provider prosms --no-start > "$test_root/prosms-pending.out" 2>&1
+assert_contains 'https://prosms.gr/sms-tool/?v=2&m=8' "$test_root/prosms-pending.out"
+assert_not_contains 'outSms.instance.upstream' "$pending_dir/conf/smsg.properties"
+assert_not_contains 'upstream::default:' "$pending_dir/conf/routingTable.conf"
+pass "pending ProSMS approval remains local-only"
+
+prosms_dir="$test_root/prosms-approved"
+SENDIUM_UPSTREAM_USERNAME='prosms-user' \
+SENDIUM_UPSTREAM_PASSWORD='pass1234' \
+    sh "$quick_start" --directory "$prosms_dir" --provider prosms --no-start > "$test_root/prosms-approved.out" 2>&1
+assert_contains 'outSms.instance.upstream.host = smpp.prosms.gr' "$prosms_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.port = 2775' "$prosms_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.username = prosms-user' "$prosms_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.password = pass1234' "$prosms_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.ssl = false' "$prosms_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.connections.transceivers = 1' "$prosms_dir/conf/smsg.properties"
+assert_contains 'upstream::default:' "$prosms_dir/conf/routingTable.conf"
+pass "approved ProSMS provider profile"
+
+custom_dir="$test_root/custom"
+SENDIUM_UPSTREAM_HOST='smpp.example.test' \
+SENDIUM_UPSTREAM_PORT='3550' \
+SENDIUM_UPSTREAM_USERNAME='custom-user' \
+SENDIUM_UPSTREAM_PASSWORD='pass1234' \
+SENDIUM_UPSTREAM_TLS='true' \
+    sh "$quick_start" --directory "$custom_dir" --provider custom --no-start > "$test_root/custom.out" 2>&1
+assert_contains 'outSms.instance.upstream.host = smpp.example.test' "$custom_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.port = 3550' "$custom_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.username = custom-user' "$custom_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.password = pass1234' "$custom_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.ssl = true' "$custom_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.connections.transceivers = 1' "$custom_dir/conf/smsg.properties"
+assert_contains 'outSms.instance.upstream.connections.transmitters = 0' "$custom_dir/conf/smsg.properties"
+pass "custom SMPP provider profile"
+
+invalid_dir="$test_root/invalid"
+expect_failure "oversized SMPP password" "$test_root/password.out" \
+    env SENDIUM_UPSTREAM_USERNAME='prosms-user' \
+        SENDIUM_UPSTREAM_PASSWORD='password9' \
+        sh "$quick_start" --directory "$invalid_dir" --provider prosms --no-start
+assert_contains 'password must not exceed 8 bytes' "$test_root/password.out"
+pass "invalid SMPP provider input"
+
+multiline_host=$(printf 'smpp.example.test\noutSms.instance.smpp.enable = false')
+expect_failure "multiline SMPP host" "$test_root/multiline-host.out" \
+    env SENDIUM_UPSTREAM_HOST="$multiline_host" \
+        SENDIUM_UPSTREAM_USERNAME='custom-user' \
+        SENDIUM_UPSTREAM_PASSWORD='pass1234' \
+        sh "$quick_start" --directory "$test_root/multiline-host" --provider custom --no-start
+assert_contains 'SMPP host cannot contain control characters' "$test_root/multiline-host.out"
+pass "multiline SMPP property input"
+
+destination_dir="$test_root/destination-guard"
+mkdir -p "$destination_dir/compose.yml"
+expect_failure "generated destination guard" "$test_root/destination.out" \
+    sh "$quick_start" --directory "$destination_dir" --provider local --force --no-start
+assert_contains 'generated file path is not a regular file' "$test_root/destination.out"
+pass "generated destination guard"
+
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+    docker compose -f "$local_dir/compose.yml" --project-directory "$local_dir" config --quiet
+    docker compose -f "$prosms_dir/compose.yml" --project-directory "$prosms_dir" config --quiet
+    docker compose -f "$custom_dir/compose.yml" --project-directory "$custom_dir" config --quiet
+    pass "Docker Compose parsing"
+else
+    printf 'skip - Docker Compose parsing (Docker Compose unavailable)\n'
+fi
+
+if [ -n "${SENDIUM_TEST_IMAGE-}" ]; then
+    integration_dir="$test_root/integration"
+    integration_project="sendium-quickstart-test-$$"
+    COMPOSE_PROJECT_NAME="$integration_project" sh "$quick_start" \
+        --directory "$integration_dir" \
+        --provider local \
+        --image "$SENDIUM_TEST_IMAGE" > "$test_root/integration.out" 2>&1
+    assert_contains 'Sendium is ready.' "$test_root/integration.out"
+    assert_contains 'Follow live logs with:' "$test_root/integration.out"
+    integration_http_user=$(sed -n "s/^SENDIUM_HTTP_USER='\([^']*\)'$/\1/p" "$integration_dir/.sendium.env")
+    integration_http_password=$(sed -n "s/^SENDIUM_HTTP_PASSWORD='\([^']*\)'$/\1/p" "$integration_dir/.sendium.env")
+    http_status=$(curl -sS -o "$test_root/sendsms.out" -w '%{http_code}' -G http://127.0.0.1:8080/sendsms \
+        --data-urlencode "username=$integration_http_user" \
+        --data-urlencode "password=$integration_http_password" \
+        --data-urlencode 'from=Sendium' \
+        --data-urlencode 'to=306910000000' \
+        --data-urlencode 'text=Quick-start integration test')
+    assert_equals 202 "$http_status" "generated HTTP credential submission"
+    grep -E '^[0-9a-f-]{36}$' "$test_root/sendsms.out" >/dev/null 2>&1 || fail "expected gateway UUID response"
+    pass "real container startup, readiness, and HTTP submission"
+
+    original_container_id=$(docker compose -p "$integration_project" -f "$integration_dir/compose.yml" --project-directory "$integration_dir" ps -q sendium)
+    SENDIUM_UPSTREAM_HOST='127.0.0.1' \
+    SENDIUM_UPSTREAM_PORT='1' \
+    SENDIUM_UPSTREAM_USERNAME='test-user' \
+    SENDIUM_UPSTREAM_PASSWORD='pass1234' \
+    COMPOSE_PROJECT_NAME="$integration_project" sh "$quick_start" \
+        --directory "$integration_dir" \
+        --provider custom \
+        --image "$SENDIUM_TEST_IMAGE" \
+        --force > "$test_root/integration-force.out" 2>&1
+    recreated_container_id=$(docker compose -p "$integration_project" -f "$integration_dir/compose.yml" --project-directory "$integration_dir" ps -q sendium)
+    [ -n "$recreated_container_id" ] || fail "forced regeneration did not leave a running container"
+    [ "$original_container_id" != "$recreated_container_id" ] || fail "forced regeneration did not recreate the container"
+    assert_contains 'Recreating Sendium' "$test_root/integration-force.out"
+    attempt=0
+    while ! grep -F 'Starting: (smppclient.upstream)' "$integration_dir/logs/smsg.log" >/dev/null 2>&1 && [ "$attempt" -lt 10 ]; do
+        attempt=$((attempt + 1))
+        sleep 1
+    done
+    assert_contains 'Starting: (smppclient.upstream)' "$integration_dir/logs/smsg.log"
+    assert_not_contains "Cannot start worker 'upstream': Missing '.type' property" "$integration_dir/logs/smsg.log"
+    pass "forced regeneration recreates the running container"
+else
+    printf 'skip - real container startup (set SENDIUM_TEST_IMAGE to enable)\n'
+fi
+
+printf 'Completed %s quick-start tests.\n' "$tests_run"


### PR DESCRIPTION
# Secure Quick Start Installer

## Summary

Adds a secure, guided Quick Start installer for running Sendium with Docker Compose on Linux, macOS, and WSL.

The installer generates the required runtime configuration, credentials, directories, and Compose file. It can then start Sendium and wait for it to become ready.

## Why

Previously, evaluating Sendium required manually creating several configuration files and understanding its authentication, routing, and SMPP worker settings.

This change provides a safer and more approachable setup while preserving explicit configuration and provider-neutral behavior.

## What Changed

- Added `quick-start.sh`.
- Added local-only, ProSMS, and custom SMPP provider modes.
- Generates secure random HTTP and SMPP credentials.
- Generates `compose.yml`, `.sendium.env`, credentials, SMPP configuration, and routing configuration.
- Binds HTTP and SMPP ports to `127.0.0.1` by default.
- Uses one transceiver for all generated upstream connections.
- Supports pending ProSMS approval without creating a broken placeholder worker.
- Validates SMPP host, port, credentials, TLS settings, and protocol length limits.
- Protects existing directories unless `--force` is explicitly supplied.
- Preserves unrelated files during forced regeneration.
- Rejects symlinked or unsafe generated destinations.
- Enforces restrictive secret-file permissions.
- Detects WSL-mounted Windows directories that cannot enforce Unix permissions.
- Starts Sendium with Docker Compose and performs an HTTP readiness check.
- Updates the README, Docker deployment guide, and HTTP API documentation.
- Adds Linux and macOS CI coverage.

## Safe Upstream Regeneration

When an upstream provider is added through forced regeneration, the installer first writes the complete worker configuration with:

```properties
outSms.instance.upstream.enable = false
After the running instance has had time to load the worker type, credentials, and connection properties, the installer atomically replaces it with:
outSms.instance.upstream.enable = true
```
This prevents the worker from starting before its .type property is available.

## Testing

Added a dependency-free POSIX shell test suite covering:
- POSIX shell syntax
- Secure local-only generation
- Generated credential consistency
- Secret-file permissions
- Non-empty directory protection
- Safe forced regeneration
- Staged upstream activation
- Pending ProSMS configuration
- Approved ProSMS configuration
- Custom SMPP configuration
- Invalid SMPP credentials
- Unsafe generated destinations
- Docker Compose parsing
The optional image-backed CI test also verifies:
- Real container startup
- HTTP readiness
- Authenticated /sendsms submission
- HTTP 202 Accepted
- UUID response generation
- Forced upstream activation in an already-running container
- Absence of the Missing '.type' property startup failure
All 11 non-image test groups pass under WSL.

## Scope Note
This PR prevents the configuration reload ordering issue in the Quick Start workflow by staging worker activation.
The underlying application-wide hot-reload race remains outside this PR and should be addressed separately.