### PR TITLE
docs: add quickstart resource requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ With over 20 years of experience building high-performance telecommunications so
 
 * Docker with Docker Compose v2.
 * `curl` and a POSIX shell.
+* At least 1 GB of RAM and 2 GB of free disk space. For a more comfortable evaluation, 2 GB of RAM and 5 GB of free disk space are recommended.
 
 ### Generate and Start Sendium
 


### PR DESCRIPTION
## Summary

- Document minimum RAM and free disk space for Quick Start.
- Add recommended capacity for a more comfortable evaluation.

## Motivation

The existing prerequisites list the required tools but do not set expectations for cloud VM resources. Explicit guidance helps users avoid undersized 512 MB instances and leaves room for the container image, runtime memory, logs, and persisted data.

## Verification

- `git diff --check`
- Documentation-only change; no runtime tests required.