### PR TITLE
docs: add repository agent workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# Repository Agent Instructions
+
+These instructions apply to all work in this repository.
+
+## Commits
+
+- Every commit must include a Developer Certificate of Origin `Signed-off-by:` trailer. Create commits with `git commit -s` and use the contributor's configured name and email.
+- Cryptographic signing does not replace the DCO trailer. When a cryptographic signature is required, use both options: `git commit -S -s`.
+- Before pushing, verify the commit message contains the expected `Signed-off-by:` trailer.
+
+## Pull Requests
+
+- A pull request may be opened only when its branch contains the latest `origin/main`.
+- Immediately before opening a pull request, run `git fetch origin main` and `git rebase origin/main`.
+- Verify `git rev-list --count HEAD..origin/main` returns `0`. Do not open the pull request if the branch is behind or the rebase is unresolved.
+- Rebasing rewrites commits. Preserve all DCO trailers and recreate cryptographic signatures when required, for example with `git rebase --gpg-sign origin/main`.
+- If a published branch must be updated after a rebase, use `git push --force-with-lease`, never `git push --force`.


### PR DESCRIPTION
## Summary

- Add repository-wide agent instructions for DCO sign-off.
- Clarify that cryptographic signing does not replace the `Signed-off-by:` trailer.
- Require branches to be rebased onto the latest `origin/main` before opening a pull request.
- Require `--force-with-lease` when a published branch must be updated after rebasing.

## Motivation

This captures the workflow lessons from the Quick Start documentation change and prevents future DCO failures or pull requests being opened from stale branches.

## Verification

- Commit has a valid SSH signature and DCO trailer.
- `git rev-list --count HEAD..origin/main` returns `0`.
- `git diff --check` passes.
- Documentation-only change; no runtime tests required.